### PR TITLE
add support for .npmrc noproxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function getProxyForUrl(url) {
  * @private
  */
 function shouldProxy(hostname, port) {
-  var NO_PROXY =
+  var NO_PROXY = getEnv('npm_config_noproxy') || 
     (getEnv('npm_config_no_proxy') || getEnv('no_proxy')).toLowerCase();
   if (!NO_PROXY) {
     return true;  // Always proxy if NO_PROXY is not set.

--- a/test.js
+++ b/test.js
@@ -479,5 +479,18 @@ describe('getProxyForUrl', function() {
       testProxyUrl(env, '', 'http://example');
       testProxyUrl(env, 'http://proxy', 'http://otherwebsite');
     });
+    // eslint-disable-next-line max-len
+    describe('npm_config_noproxy should take precedence over npm_config_no_proxy and NO_PROXY', function() {
+      var env = {};
+      env.HTTP_PROXY = 'http://proxy';
+      env.NO_PROXY = 'otherwebsite';
+      // eslint-disable-next-line camelcase
+      env.npm_config_no_proxy = 'anotherexample';
+      // eslint-disable-next-line camelcase
+      env.npm_config_noproxy = 'example';
+      testProxyUrl(env, '', 'http://example');
+      testProxyUrl(env, 'http://proxy', 'http://anotherexample');
+      testProxyUrl(env, 'http://proxy', 'http://otherwebsite');
+    });
   });
 });


### PR DESCRIPTION
Add support for 'noproxy' from .npmrc (https://docs.npmjs.com/cli/v9/using-npm/config#noproxy)
and have it takes precedence over `no_proxy` in .npmrc.

`noproxy` is npm's documented way of specifying non proxied hosts and domains.

