### PR TITLE
Add PROXY_SELECTOR support

### DIFF
--- a/proxy-for-gh.sh
+++ b/proxy-for-gh.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "$1" = "http://gh.example.com" ]; then
+  echo "http://proxy.example.com:8080"
+fi

--- a/test.js
+++ b/test.js
@@ -388,6 +388,19 @@ describe('getProxyForUrl', function() {
     testProxyUrl(env, '', 'http://zZz');
   });
 
+  describe('use proxy_selector', function() {
+    var env = {};
+    env.PROXY_SELECTOR = 'proxy-for-gh.sh';
+    env.PATH = '.';
+
+    testProxyUrl(env, '', 'http://xxx');
+    testProxyUrl(env, '', 'http://XXX');
+    testProxyUrl(env, '', 'http://yyy');
+    testProxyUrl(env, 'http://proxy.example.com:8080', 'http://gh.example.com');
+    testProxyUrl(env, '', 'http://ZzZ');
+    testProxyUrl(env, '', 'http://zZz');
+  });
+
   describe('NPM proxy configuration', function() {
     describe('npm_config_http_proxy should work', function() {
       var env = {};


### PR DESCRIPTION
Instead of set an proxy server unconditionally via *_PROXY environment variables and exclude certain host names via NO_PROXY environment variable, let's reverse the semantic by defining a new environment variable PROXY_SELECTOR which points to an executable that is passed a URI as first argument and will return on stdout line by line a proxy eligible for the input argument.

This will enable a more flexible proxy configuration in complex setups and by reversing the semantic, allow explicit proxy configuration of only know URIs.