### PR TITLE
Restore CJS support for Node versions before 20

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,6 +11,27 @@ jobs:
     - run: npm install # install eslint
     - run: npm run lint
 
+  test-old-node:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version:
+          # Node 10 is the first version to introduce URL support
+          - 10.0.0
+          # Node 12 supports "exports" package.json key.
+          - 12.22.12
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js ${{ matrix.node_version }}
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ matrix.node_version }}
+
+    # Note: we only run the require() tests. Fixing the ESM test requires
+    # more effort (polyfilling missing node:test, and we don't bother).
+    - run: npm run test-require
+
   test-node:
     runs-on: ubuntu-latest
     strategy:
@@ -43,6 +64,9 @@ jobs:
     # test-coverage will also run the tests, but does not print helpful output upon test failure.
     # So we also run the tests separately.
     - run: npm test
+
+    # Sanity check that require() works.
+    - run: npm run test-require
 
     # note: --experimental-test-coverage requires Node v18.15.0+
     # note: --test-reporter=lcov requires Node v20.11.0+ (https://github.com/nodejs/node/pull/50018)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,5 +50,27 @@ export default defineConfig([
       }
     },
     rules,
+  },
+  {
+    files: ['index.cjs'],
+    languageOptions: {
+      globals: {
+        // Minimum set of globals, supported in Node.
+        process: 'readonly',
+        exports: 'readonly',
+      }
+    },
+    rules,
+  },
+  {
+    files: ['test-require.cjs'],
+    languageOptions: {
+      globals: {
+        // Minimum set of globals, supported in Node.
+        process: 'readonly',
+        require: 'readonly',
+      }
+    },
+    rules,
   }
 ]);

--- a/index.cjs
+++ b/index.cjs
@@ -1,0 +1,105 @@
+'use strict';
+
+var DEFAULT_PORTS = {
+  ftp: 21,
+  gopher: 70,
+  http: 80,
+  https: 443,
+  ws: 80,
+  wss: 443,
+};
+
+function parseUrl(urlString) {
+  try {
+    return new URL(urlString);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string|object|URL} url - The URL as a string or URL instance, or a
+ *   compatible object (such as the result from legacy url.parse).
+ * @return {string} The URL of the proxy that should handle the request to the
+ *  given URL. If no proxy is set, this will be an empty string.
+ */
+function getProxyForUrl(url) {
+  var parsedUrl = (typeof url === 'string' ? parseUrl(url) : url) || {};
+  var proto = parsedUrl.protocol;
+  var hostname = parsedUrl.host;
+  var port = parsedUrl.port;
+  if (typeof hostname !== 'string' || !hostname || typeof proto !== 'string') {
+    return '';  // Don't proxy URLs without a valid scheme or host.
+  }
+
+  proto = proto.split(':', 1)[0];
+  // Stripping ports in this way instead of using parsedUrl.hostname to make
+  // sure that the brackets around IPv6 addresses are kept.
+  hostname = hostname.replace(/:\d*$/, '');
+  port = parseInt(port) || DEFAULT_PORTS[proto] || 0;
+  if (!shouldProxy(hostname, port)) {
+    return '';  // Don't proxy URLs that match NO_PROXY.
+  }
+
+  var proxy = getEnv(proto + '_proxy') || getEnv('all_proxy');
+  if (proxy && proxy.indexOf('://') === -1) {
+    // Missing scheme in proxy, default to the requested URL's scheme.
+    proxy = proto + '://' + proxy;
+  }
+  return proxy;
+}
+
+/**
+ * Determines whether a given URL should be proxied.
+ *
+ * @param {string} hostname - The host name of the URL.
+ * @param {number} port - The effective port of the URL.
+ * @returns {boolean} Whether the given URL should be proxied.
+ * @private
+ */
+function shouldProxy(hostname, port) {
+  var NO_PROXY = getEnv('no_proxy').toLowerCase();
+  if (!NO_PROXY) {
+    return true;  // Always proxy if NO_PROXY is not set.
+  }
+  if (NO_PROXY === '*') {
+    return false;  // Never proxy if wildcard is set.
+  }
+
+  return NO_PROXY.split(/[,\s]/).every(function(proxy) {
+    if (!proxy) {
+      return true;  // Skip zero-length hosts.
+    }
+    var parsedProxy = proxy.match(/^(.+):(\d+)$/);
+    var parsedProxyHostname = parsedProxy ? parsedProxy[1] : proxy;
+    var parsedProxyPort = parsedProxy ? parseInt(parsedProxy[2]) : 0;
+    if (parsedProxyPort && parsedProxyPort !== port) {
+      return true;  // Skip if ports don't match.
+    }
+
+    if (!/^[.*]/.test(parsedProxyHostname)) {
+      // No wildcards, so stop proxying if there is an exact match.
+      return hostname !== parsedProxyHostname;
+    }
+
+    if (parsedProxyHostname.charAt(0) === '*') {
+      // Remove leading wildcard.
+      parsedProxyHostname = parsedProxyHostname.slice(1);
+    }
+    // Stop proxying if the hostname ends with the no_proxy host.
+    return !hostname.endsWith(parsedProxyHostname);
+  });
+}
+
+/**
+ * Get the value for an environment variable.
+ *
+ * @param {string} key - The name of the environment variable.
+ * @return {string} The value of the environment variable.
+ * @private
+ */
+function getEnv(key) {
+  return process.env[key.toLowerCase()] || process.env[key.toUpperCase()] || '';
+}
+
+exports.getProxyForUrl = getProxyForUrl;

--- a/package.json
+++ b/package.json
@@ -2,11 +2,16 @@
   "name": "proxy-from-env",
   "version": "2.0.0",
   "description": "Offers getProxyForUrl to get the proxy URL for a URL, respecting the *_PROXY (e.g. HTTP_PROXY) and NO_PROXY environment variables.",
-  "main": "index.js",
-  "exports": "./index.js",
+  "main": "index.cjs",
+  "exports": {
+    "import": "./index.js",
+    "require": "./index.cjs"
+  },
+  "files": ["index.js", "index.cjs"],
   "scripts": {
-    "lint": "eslint *.js *.mjs",
+    "lint": "eslint *.js *.mjs *.cjs",
     "test": "node --test ./test.js",
+    "test-require": "node ./test-require.cjs",
     "test-coverage": "node --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info ./test.js",
     "test-coverage-as-html": "npm run test-coverage && genhtml lcov.info -o coverage/"
   },
@@ -31,5 +36,8 @@
     "eslint": "^9.39.2"
   },
   "type": "module",
+  "engines": {
+    "node": ">=10"
+  },
   "sideEffects": false
 }

--- a/test-require.cjs
+++ b/test-require.cjs
@@ -1,0 +1,53 @@
+eval( // First line so that the line numbers in assertions match.
+  (() => {
+    const {readFileSync} = require('fs');
+    const filename = require('path').join(__dirname, 'test.js');
+    let txt = readFileSync(filename, {encoding: 'utf-8'});
+    function replaceSource(lineSource, lineReplacement) {
+      if (!txt.includes(lineSource)) {
+        throw new Error(`Line not found: ${lineSource}`);
+      }
+      txt = txt.replace(lineSource, lineReplacement);
+    }
+    // describe/it is stable since Node 20. Fall back to a minimal polyfill
+    // for older versions.
+    replaceSource(
+      String.raw`import {describe, it} from 'node:test';`,
+      String.raw`function describe(t,f){f()}function it(t,f){f()}`
+    );
+    replaceSource(
+      String.raw`import assert from 'node:assert';`,
+      String.raw`const assert = require('assert');`
+
+    );
+    replaceSource(
+      String.raw`import {parse as parseUrl} from 'node:url';`,
+      String.raw`const {parse: parseUrl} = require('url');`
+    );
+    // This is why we go through the effort at all: verify that require() works.
+    replaceSource(
+      String.raw`import {getProxyForUrl} from 'proxy-from-env';`,
+      String.raw`const {getProxyForUrl} = require('proxy-from-env');`
+    );
+    if (process.version.startsWith('v10.')) {
+      // Need to require directory instead of package name in Node 10 to avoid:
+      // Error: Cannot find module 'proxy-from-env'
+      replaceSource(
+        String.raw`require('proxy-from-env');`,
+        String.raw`require('.');`
+      );
+    }
+
+    // URL.canParse was introduced in Node 18. Polyfill it, but only its usage
+    // in tests so that we fail if the implementation were to rely on it.
+    replaceSource(
+      String.raw`URL.canParse(`,
+      String.raw`(u=>{try{new URL(u);return true;}catch{return false;}})(`
+    );
+
+    txt +=
+      String.raw`// The test is quiet by default, log something.
+      console.log('Ran tests with require(proxy-from-env)');`;
+    return txt;
+  })()
+);

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 /* eslint max-statements:0 */
 'use strict';
 
+// Note: this file also runs via test-require.cjs, with imports replaced.
+
 import {describe, it} from 'node:test';
 import assert from 'node:assert';
 import {parse as parseUrl} from 'node:url';


### PR DESCRIPTION
In 2.0.0 I dropped CJS support because `require(esm)` is supported by default in v20.19.0, and `import` syntax even works in `v12.17.0`.

Despite anything earlier than 20 being EOL (and 20 itself going EOL next month - https://nodejs.org/en/about/previous-releases ), some downstream packages still want to support older Node versions.

This restores CJS support for versions as low as Node 10. Older versions are unsupported due to the absence of the URL global in older versions.

index.cjs is a copy of index.js, except using CJS exports instead of ESM exports. These files should be kept in sync until we drop CJS support again.